### PR TITLE
Amend PaySession to not force unwrap shipping contact

### DIFF
--- a/Pay/PayAuthorization.swift
+++ b/Pay/PayAuthorization.swift
@@ -39,7 +39,7 @@ public struct PayAuthorization {
     public let billingAddress: PayAddress
 
     /// Shipping address that was selected by the user
-    public let shippingAddress: PayAddress
+    public let shippingAddress: PayAddress?
 
     /// Shipping rate that was selected by the user
     public let shippingRate: PayShippingRate?
@@ -47,7 +47,7 @@ public struct PayAuthorization {
     // ----------------------------------
     //  MARK: - Init -
     //
-    internal init(paymentData: Data, billingAddress: PayAddress, shippingAddress: PayAddress, shippingRate: PayShippingRate?) {
+    internal init(paymentData: Data, billingAddress: PayAddress, shippingAddress: PayAddress?, shippingRate: PayShippingRate?) {
         self.token           = String(data: paymentData, encoding: .utf8)!
         self.billingAddress  = billingAddress
         self.shippingAddress = shippingAddress

--- a/Pay/PaySession.swift
+++ b/Pay/PaySession.swift
@@ -248,7 +248,7 @@ extension PaySession: PKPaymentAuthorizationControllerDelegate {
         let authorization = PayAuthorization(
             paymentData:     payment.token.paymentData,
             billingAddress:  PayAddress(with: payment.billingContact!),
-            shippingAddress: PayAddress(with: payment.shippingContact!),
+            shippingAddress: payment.shippingContact != nil ? PayAddress(with: payment.shippingContact!) : nil,
             shippingRate:    shippingRate
         )
         


### PR DESCRIPTION
### What this does
This will prevent app from crashing when forcefully unwrapping shipping contact when buying gift-cards only with Apple Pay.

<# Describe your changes #>
Make `shippingAddress` optional in PayAuthorization

